### PR TITLE
Migrated from 0.20.2 to 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
 target/
-dbt_modules/
+dbt_packages/
 logs/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,12 +2,15 @@ name: 'shipstation'
 
 config-version: 2
 version: '1.0'
+require-dbt-version: ">=1.0.0"
 
-source-paths: ["models"]
-analysis-paths: ["analysis"]
+model-paths: ["models"]
+analysis-paths: ["analyses"]
 target-path: "target"
-clean-targets: ["target"]
-test-paths: ["test"]
+clean-targets: 
+    - "target"
+    - "dbt_packages"
+test-paths: ["tests"]
 
 profile: lacolombe-dtc
 


### PR DESCRIPTION
https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.0

The only relevant changes for us are in dbt_project.yml file:

- Added explicit version requirement: require-dbt-version: ">=1.0.0"
- source-paths => model-paths
- default test-paths went from test to tests
- default analysis-paths went from analysis to analyses
- data-paths => seed-paths
- dbt_modules => dbt_packages in clean-targets