### PR TITLE
added a shipstation order items table

### DIFF
--- a/models/tables/shipstation_order_items.sql
+++ b/models/tables/shipstation_order_items.sql
@@ -1,0 +1,26 @@
+{{
+config({
+    "materialized" : "table",
+    "sort" : "modified_at",
+    "post-hook" : [
+      "grant select on table {{this}} to group non_gl_read_only"
+      ]
+    })
+}}
+
+select
+--IDs
+_sdc_source_key_orderid as order_id,
+orderitemid as order_item_id,
+productid as product_id,
+lineitemkey as line_item_key,
+--product descriptions
+name,
+sku,
+quantity,
+unitprice as unit_price,
+warehouselocation as warehouse_location,
+--timestamps
+createdate::date as created_at,
+modifydate::date as modified_at
+from shipstation.orders__items


### PR DESCRIPTION
Created a ShipStation order items table for the purpose of using this as a data source for a dashboard that compares orders in Shopify and orders in ShipStation. 