### PR TITLE
added meltano shipstation data to order items model

### DIFF
--- a/models/tables/shipstation_order_items.sql
+++ b/models/tables/shipstation_order_items.sql
@@ -8,6 +8,9 @@ config({
     })
 }}
 
+
+--Old Tap 
+
 select
 --IDs
 _sdc_source_key_orderid as order_id,
@@ -24,3 +27,28 @@ warehouselocation as warehouse_location,
 createdate::date as created_at,
 modifydate::date as modified_at
 from shipstation.orders__items
+where createdate::date < '2022-09-20'
+
+union all
+
+--Meltano Tap
+
+select
+--IDs
+_sdc_source_key_orderid as order_id,
+orderitemid as order_item_id,
+productid as product_id,
+lineitemkey as line_item_key,
+--product descriptions
+name,
+sku,
+quantity,
+unitprice as unit_price,
+warehouselocation as warehouse_location,
+--timestamps
+createdate::date as created_at,
+modifydate::date as modified_at
+from meltano_shipstation.orders__items
+where createdate::date >= '2022-09-20'
+
+


### PR DESCRIPTION
This model was previously missing data before the date 9-20-22.

now, all data before 9-20-22 is pulled from shipstation
and all data after or on 9-20-22 is pulled from meltano_shipstation 